### PR TITLE
Updates to Module 2 notebooks

### DIFF
--- a/Jupyter/M02-Python/M02G-AdvDataTypes.ipynb
+++ b/Jupyter/M02-Python/M02G-AdvDataTypes.ipynb
@@ -1146,7 +1146,7 @@
       "source": [
         "**Traverse a dictionary**\n",
         "\n",
-        "The key-value pairs in a dictionary are **not** ordered in any manner. The following example uses **for** loop to traversal a dictionary. Notice that the keys are in no particular order."
+        "Since Python 3.7, dictionaries maintain insertion order, meaning the order in which items are added is preserved. The following example uses a **for** loop to traverse a dictionary. Notice that the keys are in the order of insertion."
       ]
     },
     {

--- a/Jupyter/M02-Python/M02H-Packages.ipynb
+++ b/Jupyter/M02-Python/M02H-Packages.ipynb
@@ -111,7 +111,7 @@
     "id": "YLU8yilr-FCa"
    },
    "source": [
-    "For a complete list of Python standard library and their documentation look at the [Python Manual.](https://docs.python.org/2/library/) A few to mention are:\n",
+    "For a complete list of Python standard library and their documentation look at the [Python Manual.](https://docs.python.org/3/library/) A few to mention are:\n",
     "\n",
     "* ``math`` for numeric and math-related functions and data types\n",
     "* ``urllib`` for fetching data across the web\n",


### PR DESCRIPTION
Update M02G-AdcDataTypes. Notebook states dictionaries are not ordered. However, from version 3.7, they are ordered based on insertion order.

Update M02H-Packages. The documentation link takes you to Python 2!. Changes to take to Python 3.
